### PR TITLE
Fix group membership sync not propagating user removals to Talk

### DIFF
--- a/lib/Backend/GroupBackend.php
+++ b/lib/Backend/GroupBackend.php
@@ -498,6 +498,27 @@ final class GroupBackend extends ABackend implements
     }
 
     /**
+     * Invalidate cached membership data for a single user/group pair so that
+     * subsequent lookups (getUserGroups, inGroup, usersInGroup, …) reflect the
+     * current state of the external SQL database. Must be called whenever a
+     * membership change is detected outside of this Nextcloud instance, before
+     * dispatching group membership events – otherwise listeners (e.g. Talk)
+     * may read stale group memberships from this backend.
+     *
+     * @param string $uid The user ID whose membership has changed.
+     * @param string $gid The group ID whose membership has changed.
+     */
+    public function invalidateUserGroupCache(string $uid, string $gid): void
+    {
+        $prefix = self::class;
+        $this->cache->remove($prefix . "user_groups_" . $uid);
+        $this->cache->remove($prefix . "user_group_" . $uid . "_" . $gid);
+        $this->cache->clear($prefix . "group_uids_" . $gid . "_");
+        $this->cache->clear($prefix . "group_users_" . $gid . "_");
+        $this->cache->clear($prefix . "users#_" . $gid . "_");
+    }
+
+    /**
      * Check if this backend is correctly set and can be enabled.
      *
      * @return bool TRUE if all necessary options for this backend

--- a/lib/BackgroundJob/SyncGroupMembership.php
+++ b/lib/BackgroundJob/SyncGroupMembership.php
@@ -29,7 +29,7 @@ class SyncGroupMembership extends TimedJob {
 		try {
 			$result = $this->syncService->sync();
 			$this->logger->info(
-				"Group membership sync completed: {$result['added']} added, {$result['removed']} removed, {$result['errors']} errors"
+				"Group membership sync completed: {$result['added']} added, {$result['removed']} removed, {$result['skipped']} skipped, {$result['errors']} errors"
 			);
 		} catch (\Exception $e) {
 			$this->logger->error('Group membership sync failed: ' . $e->getMessage(), [

--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -96,12 +96,26 @@ class Cache
     }
 
     /**
-     * Clear the cache of all entries.
+     * Clear the cache of all entries matching the given prefix.
+     *
+     * @param string $prefix (optional) Key prefix. Defaults to "" (clear all).
      *
      * @return bool TRUE on success, FALSE otherwise.
      */
-    public function clear()
+    public function clear($prefix = "")
     {
-        return $this->cache->clear();
+        return $this->cache->clear($prefix);
+    }
+
+    /**
+     * Remove a single value from the cache memory.
+     *
+     * @param string $key The cache value key.
+     *
+     * @return bool TRUE on success, FALSE otherwise.
+     */
+    public function remove($key)
+    {
+        return $this->cache->remove($key);
     }
 }

--- a/lib/Command/SyncGroups.php
+++ b/lib/Command/SyncGroups.php
@@ -47,7 +47,7 @@ class SyncGroups extends Command {
 
 		$elapsed = round(microtime(true) - $start, 2);
 		$prefix = $options['dry_run'] ? '[DRY-RUN] ' : '';
-		$output->writeln("{$prefix}Sync completed in {$elapsed}s: {$result['added']} added, {$result['removed']} removed, {$result['errors']} errors");
+		$output->writeln("{$prefix}Sync completed in {$elapsed}s: {$result['added']} added, {$result['removed']} removed, {$result['skipped']} skipped, {$result['errors']} errors");
 
 		return $result['errors'] > 0 ? 1 : 0;
 	}

--- a/lib/Controller/GroupChangeController.php
+++ b/lib/Controller/GroupChangeController.php
@@ -4,27 +4,34 @@ declare(strict_types=1);
 
 namespace OCA\UserSQL\Controller;
 
+use OC\Hooks\PublicEmitter;
+use OCA\UserSQL\Backend\GroupBackend;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Group\Events\UserAddedEvent;
 use OCP\Group\Events\UserRemovedEvent;
+use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUser;
 use OCP\IUserManager;
 use OCP\EventDispatcher\IEventDispatcher;
 
 class GroupChangeController extends Controller {
 
-	private $dispatcher;
+	private IEventDispatcher $dispatcher;
 
-	private $userManager;
+	private IUserManager $userManager;
 
-	private $groupManager;
+	private IGroupManager $groupManager;
 
-	public function __construct(string $appName, IRequest $request, IEventDispatcher $eventDispatcher, IUserManager $userManager, IGroupManager $groupManager) {
+	private GroupBackend $groupBackend;
+
+	public function __construct(string $appName, IRequest $request, IEventDispatcher $eventDispatcher, IUserManager $userManager, IGroupManager $groupManager, GroupBackend $groupBackend) {
 		$this->dispatcher = $eventDispatcher;
 		$this->userManager = $userManager;
 		$this->groupManager = $groupManager;
+		$this->groupBackend = $groupBackend;
 		parent::__construct($appName, $request);
 	}
 
@@ -35,6 +42,12 @@ class GroupChangeController extends Controller {
 
 		$ud = base64_decode($username);
 		$gd = base64_decode($groupname);
+
+		// Drop our membership cache before resolving the IUser/IGroup so that
+		// listeners (e.g. Nextcloud Talk) querying memberships during the
+		// dispatched event read the freshly synced state.
+		$this->groupBackend->invalidateUserGroupCache($ud, $gd);
+
 		$user = $this->userManager->get($ud);
 		$group = $this->groupManager->get($gd);
 
@@ -42,10 +55,14 @@ class GroupChangeController extends Controller {
 
 			$done = false;
 			if ($operation === 'join') {
+				$this->emitLegacyHook('preAddUser', $group, $user);
 				$this->dispatcher->dispatchTyped(new UserAddedEvent($group, $user));
+				$this->emitLegacyHook('postAddUser', $group, $user);
 				$done = true;
 			} else if ($operation === 'leave') {
+				$this->emitLegacyHook('preRemoveUser', $group, $user);
 				$this->dispatcher->dispatchTyped(new UserRemovedEvent($group, $user));
+				$this->emitLegacyHook('postRemoveUser', $group, $user);
 				$done = true;
 			}
 
@@ -72,5 +89,15 @@ class GroupChangeController extends Controller {
 				]
 			]
 		);
+	}
+
+	private function emitLegacyHook(string $method, IGroup $group, IUser $user): void {
+		// OC\Group\Manager listens to these legacy hooks and clears its
+		// internal cachedUserGroups. The typed events alone do NOT clear it,
+		// which causes IGroupManager::getUserGroupIds() to return stale data
+		// to listeners reacting to UserAddedEvent / UserRemovedEvent.
+		if ($this->groupManager instanceof PublicEmitter) {
+			$this->groupManager->emit('\OC\Group', $method, [$group, $user]);
+		}
 	}
 }

--- a/lib/Service/GroupSyncService.php
+++ b/lib/Service/GroupSyncService.php
@@ -4,19 +4,24 @@ declare(strict_types=1);
 
 namespace OCA\UserSQL\Service;
 
+use OC\Hooks\PublicEmitter;
+use OCA\UserSQL\Backend\GroupBackend;
 use OCA\UserSQL\Repository\GroupRepository;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Group\Events\UserAddedEvent;
 use OCP\Group\Events\UserRemovedEvent;
 use OCP\IDBConnection;
+use OCP\IGroup;
 use OCP\IGroupManager;
+use OCP\IUser;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 class GroupSyncService {
 
 	private GroupRepository $groupRepository;
+	private GroupBackend $groupBackend;
 	private IDBConnection $db;
 	private IEventDispatcher $dispatcher;
 	private IUserManager $userManager;
@@ -25,6 +30,7 @@ class GroupSyncService {
 
 	public function __construct(
 		GroupRepository $groupRepository,
+		GroupBackend $groupBackend,
 		IDBConnection $db,
 		IEventDispatcher $dispatcher,
 		IUserManager $userManager,
@@ -32,6 +38,7 @@ class GroupSyncService {
 		LoggerInterface $logger
 	) {
 		$this->groupRepository = $groupRepository;
+		$this->groupBackend = $groupBackend;
 		$this->db = $db;
 		$this->dispatcher = $dispatcher;
 		$this->userManager = $userManager;
@@ -41,16 +48,15 @@ class GroupSyncService {
 
 	/**
 	 * @param array{dry_run?: bool, reset?: bool, group?: string} $options
-	 * @return array{added: int, removed: int, errors: int, details: string[]}
+	 * @return array{added: int, removed: int, errors: int, skipped: int, details: string[]}
 	 */
 	public function sync(array $options = []): array {
 		$dryRun = $options['dry_run'] ?? false;
 		$reset = $options['reset'] ?? false;
 		$filterGroup = $options['group'] ?? null;
 
-		$result = ['added' => 0, 'removed' => 0, 'errors' => 0, 'details' => []];
+		$result = ['added' => 0, 'removed' => 0, 'errors' => 0, 'skipped' => 0, 'details' => []];
 
-		// Reset snapshot if requested
 		if ($reset && !$dryRun) {
 			$this->db->getQueryBuilder()
 				->delete('usersql_group_sync')
@@ -58,7 +64,6 @@ class GroupSyncService {
 			$result['details'][] = 'Snapshot table reset';
 		}
 
-		// Get all groups from external DB
 		$groups = $this->groupRepository->findAllBySearchTerm('%');
 		if ($groups === false) {
 			$this->logger->error('Failed to fetch groups from external DB');
@@ -72,7 +77,7 @@ class GroupSyncService {
 		}
 
 		if ($filterGroup !== null) {
-			if (!in_array($filterGroup, $currentGids)) {
+			if (!in_array($filterGroup, $currentGids, true)) {
 				$result['details'][] = "Group '{$filterGroup}' not found in external DB";
 				$result['errors']++;
 				return $result;
@@ -80,24 +85,17 @@ class GroupSyncService {
 			$currentGids = [$filterGroup];
 		}
 
-		// Load entire snapshot in one query
 		$snapshot = $this->loadSnapshot();
 
-		// Detect deleted groups (in snapshot but not in current)
 		$snapshotGids = array_keys($snapshot);
-		$deletedGids = array_diff($snapshotGids, $currentGids);
-		if ($filterGroup !== null) {
-			$deletedGids = []; // Don't process deleted groups when filtering
-		}
+		$deletedGids = $filterGroup !== null ? [] : array_diff($snapshotGids, $currentGids);
 
-		// Process deleted groups
 		foreach ($deletedGids as $gid) {
 			foreach ($snapshot[$gid] as $uid) {
 				$this->processRemoval($gid, $uid, $dryRun, $result);
 			}
 		}
 
-		// Process each current group
 		foreach ($currentGids as $gid) {
 			$currentMembers = $this->groupRepository->findAllUidsBySearchTerm($gid, '%');
 			if ($currentMembers === false) {
@@ -124,6 +122,13 @@ class GroupSyncService {
 	}
 
 	private function processAddition(string $gid, string $uid, bool $dryRun, array &$result): void {
+		// Invalidate our own membership cache before resolving the user/group
+		// so that getUserGroups()/inGroup()/usersInGroup() reflect the current
+		// external state rather than a stale cache entry.
+		if (!$dryRun) {
+			$this->groupBackend->invalidateUserGroupCache($uid, $gid);
+		}
+
 		$user = $this->userManager->get($uid);
 		$group = $this->groupManager->get($gid);
 
@@ -134,6 +139,7 @@ class GroupSyncService {
 			if ($group === null) {
 				$result['details'][] = "Skip add: group '{$gid}' not found in Nextcloud";
 			}
+			$result['skipped']++;
 			return;
 		}
 
@@ -141,23 +147,57 @@ class GroupSyncService {
 		$result['details'][] = ($dryRun ? '[DRY-RUN] ' : '') . "Added '{$uid}' to '{$gid}'";
 
 		if (!$dryRun) {
+			$this->emitLegacyHook('preAddUser', $group, $user);
 			$this->dispatcher->dispatchTyped(new UserAddedEvent($group, $user));
+			$this->emitLegacyHook('postAddUser', $group, $user);
 			$this->insertSnapshot($gid, $uid);
 		}
 	}
 
 	private function processRemoval(string $gid, string $uid, bool $dryRun, array &$result): void {
+		// Critical: invalidate our caches BEFORE Talk (and other listeners)
+		// react to the typed event. Talk calls IGroupManager::getUserGroupIds()
+		// from its UserRemovedEvent listener to decide whether the user is
+		// still a member of the group via another link; if our cache still
+		// reports the user as a member, Talk will not remove them from the
+		// linked rooms.
+		if (!$dryRun) {
+			$this->groupBackend->invalidateUserGroupCache($uid, $gid);
+		}
+
 		$user = $this->userManager->get($uid);
 		$group = $this->groupManager->get($gid);
+
+		if ($user === null || $group === null) {
+			// Nothing to notify – the user or group no longer exists in
+			// Nextcloud. Drop the snapshot entry so we do not retry forever.
+			if (!$dryRun) {
+				$this->deleteSnapshot($gid, $uid);
+			}
+			$result['skipped']++;
+			$result['details'][] = "Skip remove: user '{$uid}' or group '{$gid}' not in Nextcloud";
+			return;
+		}
 
 		$result['removed']++;
 		$result['details'][] = ($dryRun ? '[DRY-RUN] ' : '') . "Removed '{$uid}' from '{$gid}'";
 
 		if (!$dryRun) {
-			if ($user !== null && $group !== null) {
-				$this->dispatcher->dispatchTyped(new UserRemovedEvent($group, $user));
-			}
+			// Emitting the legacy '\OC\Group::preRemoveUser' hook is required
+			// because OC\Group\Manager listens to it to clear its own
+			// cachedUserGroups. Without this, IGroupManager::getUserGroupIds()
+			// returns a stale list that still contains $gid, and Talk keeps
+			// the user in the conversation.
+			$this->emitLegacyHook('preRemoveUser', $group, $user);
+			$this->dispatcher->dispatchTyped(new UserRemovedEvent($group, $user));
+			$this->emitLegacyHook('postRemoveUser', $group, $user);
 			$this->deleteSnapshot($gid, $uid);
+		}
+	}
+
+	private function emitLegacyHook(string $method, IGroup $group, IUser $user): void {
+		if ($this->groupManager instanceof PublicEmitter) {
+			$this->groupManager->emit('\OC\Group', $method, [$group, $user]);
 		}
 	}
 


### PR DESCRIPTION
When the SQL group sync detected a user had been removed from a group, it dispatched UserRemovedEvent but Talk kept the user in conversations linked to that group. Two stacked caches were returning stale memberships to Talk's listener:

* OC\Group\Manager keeps an in-memory cachedUserGroups array that is cleared only by the legacy '\OC\Group::preRemoveUser' hook; the typed UserRemovedEvent does not clear it. Talk's GroupMembershipListener calls IGroupManager::getUserGroupIds() to decide whether the user is still linked to the room via another group, so a stale entry made it skip the removal.
* user_sql's own GroupBackend caches getUserGroups / inGroup / usersInGroup results, so even with the manager cache cleared the next call would re-cache the pre-sync state from this backend.

Both caches are now invalidated for the affected (uid, gid) pair before dispatching the event, and the legacy preRemoveUser/postRemoveUser hooks are emitted alongside UserRemovedEvent so OC\Group\Manager clears its cachedUserGroups. The same wiring is applied to the addition path and to the manual /api/sync controller for consistency.

Also stop counting skipped (uid|gid not in Nextcloud) cases as "removed"/"added" and surface them under a new "skipped" counter.